### PR TITLE
Remove p-immediate

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ Now you can configure AVA to require this file in all test processes. In
 ```
 
 Now you can `require` / `import` `.vue` files and test like you would in a
-browser! If you need to test DOM updates, you can use `Vue.nextTick` along with `async` / `await`.
+browser! If you need to test DOM updates, you can use `Vue.nextTick` along
+with `async` / `await`.
 
 ```js
 import Vue from 'vue';

--- a/README.md
+++ b/README.md
@@ -51,13 +51,11 @@ Now you can configure AVA to require this file in all test processes. In
 ```
 
 Now you can `require` / `import` `.vue` files and test like you would in a
-browser! If you need to test DOM updates, I recommend using the [`p-immediate`]
-package from npm along with `async` / `await`.
+browser! If you need to test DOM updates, you can use `Vue.nextTick` along with `async` / `await`.
 
 ```js
 import Vue from 'vue';
 import test from 'ava';
-import nextTick from 'p-immediate';
 import TestComponent from './test.vue';
 
 test('renders the correct message', async (t) => {
@@ -66,7 +64,7 @@ test('renders the correct message', async (t) => {
   t.is(vm.$el.querySelector('h1').textContent, 'Hello, World!');
   // Update
   vm.setName('Foo');
-  await nextTick();
+  await Vue.nextTick();
   t.is(vm.$el.querySelector('h1').textContent, 'Hello, Foo!');
 });
 ```

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "eslint-config-airbnb-base": "^11.1.0",
     "eslint-plugin-html": "^2.0.0",
     "eslint-plugin-import": "^2.2.0",
-    "p-immediate": "^2.1.0",
     "vue": "^2.1.10",
     "vue-loader": "^10.3.0",
     "vue-template-compiler": "^2.1.10",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,7 +2,6 @@
 import _ from 'lodash';
 import Vue from 'vue';
 import test from 'ava';
-import nextTick from 'p-immediate';
 import TestComponent from './test.vue';
 
 test('has a created hook', (t) => {
@@ -20,10 +19,10 @@ test('renders the correct message', async (t) => {
   t.is(vm.$el.querySelector('h1').textContent, 'Hello, World!');
   // Update
   vm.setName('Foo');
-  await nextTick();
+  await Vue.nextTick();
   t.is(vm.$el.querySelector('h1').textContent, 'Hello, Foo!');
   // Update directly 👻
   vm._data.name = 'Bar';
-  await nextTick();
+  await Vue.nextTick();
   t.is(vm.$el.querySelector('h1').textContent, 'Hello, Bar!');
 });


### PR DESCRIPTION
Starting with Vue 2.1.0 `Vue.nextTick()` returns a promise if you don't send any attributes so `p-immediate` is not required anymore.